### PR TITLE
fix(config): restore APIKEY field name for backward compatibility

### DIFF
--- a/config/llm.go
+++ b/config/llm.go
@@ -11,7 +11,7 @@ type ProxyConfig struct {
 // LLMModelConfig holds LLM model selection and parameter options.
 type LLMModelConfig struct {
 	Provider    string       `json:"provider" yaml:"provider"`
-	APIKey      string       `json:"api_key" yaml:"api_key"`
+	APIKEY      string       `json:"api_key" yaml:"api_key"`
 	BaseURL     string       `json:"base_url" yaml:"base_url"`
 	ModelName   string       `json:"model_name" yaml:"model_name"`
 	Proxy       *ProxyConfig `json:"proxy,omitempty" yaml:"proxy,omitempty"`


### PR DESCRIPTION
## Summary
- Restore `LLMModelConfig.APIKEY` field name (changed to `APIKey` in v1.23.58)
- Maintain backward compatibility with downstream projects (roc, dotpen-api, apigine)

## Changes
- `config/llm.go`: `APIKey` → `APIKEY`

## Test
- roc compiler errors resolved after this fix